### PR TITLE
Local testing enablement 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 
 *.db
+
+local_public/

--- a/frontend/main.go
+++ b/frontend/main.go
@@ -24,6 +24,7 @@ func main() {
 
 	// Set logger settings
 	log.SetOutput(os.Stdout)
+	log.SetFormatter(&log.JSONFormatter{})
 	if debug {
 		log.SetLevel(log.DebugLevel)
 	} else {

--- a/frontend/wshandler/client.go
+++ b/frontend/wshandler/client.go
@@ -209,6 +209,13 @@ func GetWS(w http.ResponseWriter, r *http.Request) {
 		ContextLogger.Debug("Meeting not found.")
 		return
 	}
+
+	// This is to enable local testing for myself. Probably stupid
+	_, disableCORS := os.LookupEnv("DISABLECORS")
+	if disableCORS {
+		upgrader.CheckOrigin = func(r *http.Request) bool { return true }
+	}
+
 	conn, err := upgrader.Upgrade(w, r, nil)
 	if err != nil {
 		log.Println(err)


### PR DESCRIPTION
Add an environment variable lookup for DISABLEWEBSOCKETORIGINCHECKexisting to disable WebSocket based origin checking to allow local testing environments to function correctly.

Ignore my local_public folder for serving static content locally. There were a decent amount of changes required to make that work properly and thus I needed to just make a copy and then manually copy changes into the "real" static content files. I'll figure out a better way to do this later.

Also just sneaking in an update to the logger here switching from ASCII to JSON format.

closes #5